### PR TITLE
Migrate from Commons Lang 2 to Commons Lang 3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,6 +88,7 @@
             ** We use 2.516 for now
         -->
         <jenkins.baseline>2.516</jenkins.baseline>
+        <ban-commons-lang-2.skip>false</ban-commons-lang-2.skip>
         <jenkins.version>${jenkins.baseline}.3</jenkins.version>
         <ban-junit4-imports.skip>false</ban-junit4-imports.skip>
         <hpi.strictBundledArtifacts>true</hpi.strictBundledArtifacts>

--- a/src/main/java/com/zimperium/plugins/zDevJenkinsUploadPlugin/ZDevHTTPClient.java
+++ b/src/main/java/com/zimperium/plugins/zDevJenkinsUploadPlugin/ZDevHTTPClient.java
@@ -7,7 +7,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.concurrent.TimeUnit;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import hudson.ProxyConfiguration;
 import hudson.util.Secret;

--- a/src/main/java/com/zimperium/plugins/zDevJenkinsUploadPlugin/ZDevUploadPlugin.java
+++ b/src/main/java/com/zimperium/plugins/zDevJenkinsUploadPlugin/ZDevUploadPlugin.java
@@ -27,7 +27,7 @@ import jenkins.model.Jenkins;
 import jenkins.tasks.SimpleBuildStep;
 import net.sf.json.JSONObject;
 import okhttp3.*;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.jenkinsci.Symbol;
 import org.apache.commons.io.FilenameUtils;
 import org.kohsuke.stapler.AncestorInPath;


### PR DESCRIPTION
This repository was previously using an inconsistent mix of versions.

Part of the effort to remove Commons Lang 2 from Jenkins core — jenkinsci/jenkins#16404,
jenkinsci/jenkins#26105. Commons Lang 2 is EOL and carries an unfixed advisory
(GHSA-j288-q9x7-2f5v).

The plugin already depends on `commons-lang3-api`; two files were still importing the
Commons Lang 2 package. This switches them over and enables the `ban-commons-lang-2` enforcer rule.

### Testing done

`mvn -B -ntp clean verify` passes locally on Java 21 / macOS.
The `ban-commons-lang-2` enforcer rule is enabled in this PR, so the build fails if an
`org.apache.commons.lang.*` import comes back.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

---

🤖 This pull request was generated with AI assistance (Claude Code) as part of a bulk migration
across Jenkins plugins. If anything here looks wrong, please comment on this PR or contact
@parameter.
